### PR TITLE
Fix failing Docker build configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig({
   ],
   server: {
     port: 8080,
-    host: 'localhost'
+    host: '0.0.0.0'
   },
   build: {
     assets: 'assets'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,10 @@ services:
       - ./src:/app/src:delegated
       - ./package.json:/app/package.json:ro
       - ./package-lock.json:/app/package-lock.json:ro
-      - ./vite.config.js:/app/vite.config.js:ro
+      - ./astro.config.mjs:/app/astro.config.mjs:ro
       - ./tailwind.config.js:/app/tailwind.config.js:ro
       - ./postcss.config.js:/app/postcss.config.js:ro
+      - ./tsconfig.json:/app/tsconfig.json:ro
       # Exclude node_modules to use container's dependencies
       - /app/node_modules
     environment:


### PR DESCRIPTION
Fixes build failures introduced during the Astro migration in issue #6.

## Changes:
- Remove non-existent vite.config.js reference from docker-compose.yml
- Add missing astro.config.mjs and tsconfig.json to Docker volumes
- Fix Astro server host to bind to 0.0.0.0 for Docker container access

Resolves #9

Generated with [Claude Code](https://claude.ai/code)