### PR TITLE
Add 10% GST to all service prices

### DIFF
--- a/src/pages/audio-services.astro
+++ b/src/pages/audio-services.astro
@@ -73,7 +73,7 @@ import Image from '../components/Image.astro';
                       >
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$100-$150 AUD</span
+                      >$110-$165 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -81,7 +81,7 @@ import Image from '../components/Image.astro';
                       <span class="font-semibold block">Extended Edit (30-60 min)</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$150-$250 AUD</span
+                      >$165-$275 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -89,7 +89,7 @@ import Image from '../components/Image.astro';
                       <span class="font-semibold block">Add-on: Custom Intro/Outro Music</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$100-$200 AUD</span
+                      >$110-$220 AUD (including GST)</span
                     >
                   </div>
                 </div>
@@ -128,7 +128,7 @@ import Image from '../components/Image.astro';
                       >
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$150 AUD</span
+                      >$165 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -136,7 +136,7 @@ import Image from '../components/Image.astro';
                       <span class="font-semibold block">Add-on: Background Music Sync</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$50 AUD</span
+                      >$55 AUD (including GST)</span
                     >
                   </div>
                 </div>
@@ -173,7 +173,7 @@ import Image from '../components/Image.astro';
                       <span class="text-sm text-gray-600">e.g. vocals + background</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$100-$200 AUD</span
+                      >$110-$220 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -184,7 +184,7 @@ import Image from '../components/Image.astro';
                       >
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$80-$120 AUD</span
+                      >$88-$132 AUD (including GST)</span
                     >
                   </div>
                 </div>
@@ -221,7 +221,7 @@ import Image from '../components/Image.astro';
                       <span class="text-sm text-gray-600">Royalty-free for client use</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$200-$300 AUD</span
+                      >$220-$330 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -229,7 +229,7 @@ import Image from '../components/Image.astro';
                       <span class="font-semibold block">Loopable Background Music (1-2 min)</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$150-$250 AUD</span
+                      >$165-$275 AUD (including GST)</span
                     >
                   </div>
                 </div>
@@ -266,7 +266,7 @@ import Image from '../components/Image.astro';
                       <span class="text-sm text-gray-600">Sync to video included</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$80-$150 AUD per video</span
+                      >$88-$165 AUD per video (including GST)</span
                     >
                   </div>
                 </div>

--- a/src/pages/branding-identity.astro
+++ b/src/pages/branding-identity.astro
@@ -58,7 +58,7 @@ import Image from '../components/Image.astro';
                   well-designed professional logo will attract customers and give a good first
                   impression, which will in turn bring in more business.
                 </p>
-                <p class="text-2xl font-bold text-gray-800">$200 AUD</p>
+                <p class="text-2xl font-bold text-gray-800">$220 AUD (including GST)</p>
               </div>
             </div>
           </div>
@@ -93,7 +93,7 @@ import Image from '../components/Image.astro';
                   graphics to impress your customers. We can also help nail your brand voice and
                   messaging.
                 </p>
-                <p class="text-2xl font-bold text-gray-800">$600-$800 AUD</p>
+                <p class="text-2xl font-bold text-gray-800">$660-$880 AUD (including GST)</p>
               </div>
             </div>
           </div>
@@ -128,11 +128,11 @@ import Image from '../components/Image.astro';
                 <div class="space-y-2">
                   <p class="text-lg">
                     <span class="font-semibold">Basic:</span>
-                    <span class="text-xl font-bold text-gray-800">$100 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$110 AUD (including GST)</span>
                   </p>
                   <p class="text-lg">
                     <span class="font-semibold">With a logo:</span>
-                    <span class="text-xl font-bold text-gray-800">$250 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$275 AUD (including GST)</span>
                   </p>
                 </div>
               </div>

--- a/src/pages/print-marketing-design.astro
+++ b/src/pages/print-marketing-design.astro
@@ -63,19 +63,19 @@ import Image from '../components/Image.astro';
                 <div class="bg-gray-50 rounded-lg p-4 space-y-3">
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Basic Flyer (1 page)</span>
-                    <span class="text-xl font-bold text-gray-800">$150 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$165 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Basic Brochure (2-4 pages)</span>
-                    <span class="text-xl font-bold text-gray-800">$300 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$330 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Advanced Flyer</span>
-                    <span class="text-xl font-bold text-gray-800">$350 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$385 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Advanced Brochure (5+ pages)</span>
-                    <span class="text-xl font-bold text-gray-800">$600 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$660 AUD (including GST)</span>
                   </div>
                 </div>
               </div>
@@ -110,15 +110,15 @@ import Image from '../components/Image.astro';
                 <div class="bg-gray-50 rounded-lg p-4 space-y-3">
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Flyer / Poster (Single-sided)</span>
-                    <span class="text-xl font-bold text-gray-800">$150 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$165 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Brochure (Bi-fold or Tri-fold)</span>
-                    <span class="text-xl font-bold text-gray-800">$200-$300 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$220-$330 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Menu / Price List Design</span>
-                    <span class="text-xl font-bold text-gray-800">$150-$250 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$165-$275 AUD (including GST)</span>
                   </div>
                 </div>
               </div>

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -46,7 +46,7 @@ import Image from '../components/Image.astro';
               Complete brand identity packages including logos, business cards, letterheads, and
               brand guidelines.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $200 AUD</p>
+            <p class="text-watt-yellow font-semibold">Starting from $220 AUD (including GST)</p>
           </div>
         </Link>
 
@@ -71,7 +71,7 @@ import Image from '../components/Image.astro';
               Professional brochures, flyers, posters, and marketing materials that capture
               attention.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $150 AUD</p>
+            <p class="text-watt-yellow font-semibold">Starting from $165 AUD (including GST)</p>
           </div>
         </Link>
 
@@ -95,7 +95,7 @@ import Image from '../components/Image.astro';
             <p class="text-gray-600 mb-4">
               Eye-catching social media graphics and content packages for all platforms.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $50 AUD</p>
+            <p class="text-watt-yellow font-semibold">Starting from $55 AUD (including GST)</p>
           </div>
         </Link>
 
@@ -119,7 +119,7 @@ import Image from '../components/Image.astro';
             <p class="text-gray-600 mb-4">
               Photography, photo editing, video production, and visual storytelling.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $100 AUD</p>
+            <p class="text-watt-yellow font-semibold">Starting from $110 AUD (including GST)</p>
           </div>
         </Link>
 
@@ -143,7 +143,7 @@ import Image from '../components/Image.astro';
             <p class="text-gray-600 mb-4">
               Podcast editing, music production, voiceovers, and audio branding.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $100 AUD</p>
+            <p class="text-watt-yellow font-semibold">Starting from $110 AUD (including GST)</p>
           </div>
         </Link>
 

--- a/src/pages/social-media-design.astro
+++ b/src/pages/social-media-design.astro
@@ -66,7 +66,7 @@ import Image from '../components/Image.astro';
                       <span class="font-semibold block">Basic Static Post</span>
                       <span class="text-sm text-gray-600">Quote graphics, announcements</span>
                     </div>
-                    <span class="text-xl font-bold text-gray-800">$50 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$55 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <div>
@@ -75,7 +75,7 @@ import Image from '../components/Image.astro';
                         >Infographics, multi-layered designs</span
                       >
                     </div>
-                    <span class="text-xl font-bold text-gray-800">$80-$100 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$88-$110 AUD (including GST)</span>
                   </div>
                 </div>
               </div>
@@ -113,19 +113,19 @@ import Image from '../components/Image.astro';
                 <div class="bg-gray-50 rounded-lg p-4 space-y-3">
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Template Pack</span>
-                    <span class="text-xl font-bold text-gray-800">$300-$500 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$330-$550 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Branded Animations</span>
-                    <span class="text-xl font-bold text-gray-800">$200-$400 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$220-$440 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Profile & Cover Photos</span>
-                    <span class="text-xl font-bold text-gray-800">$100-$200 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$110-$220 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Highlight Covers (Set of 5)</span>
-                    <span class="text-xl font-bold text-gray-800">$100-$150 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$110-$165 AUD (including GST)</span>
                   </div>
                 </div>
               </div>

--- a/src/pages/visual-content-creation.astro
+++ b/src/pages/visual-content-creation.astro
@@ -77,18 +77,18 @@ import Image from '../components/Image.astro';
                         >
                       </div>
                       <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                        >$150-$250 AUD</span
+                        >$165-$275 AUD (including GST)</span
                       >
                     </div>
                     <div class="flex justify-between items-start">
                       <div>
                         <span class="font-semibold block">Team Headshots (up to 5 people)</span>
                         <span class="text-sm text-gray-600"
-                          >Add $50-$80 per additional person</span
+                          >Add $55-$88 per additional person (including GST)</span
                         >
                       </div>
                       <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                        >$400 AUD</span
+                        >$440 AUD (including GST)</span
                       >
                     </div>
                   </div>
@@ -106,7 +106,7 @@ import Image from '../components/Image.astro';
                         >
                       </div>
                       <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                        >$200-$400 AUD</span
+                        >$220-$440 AUD (including GST)</span
                       >
                     </div>
                     <div class="flex justify-between items-start">
@@ -115,7 +115,7 @@ import Image from '../components/Image.astro';
                         <span class="text-sm text-gray-600">On-location or themed</span>
                       </div>
                       <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                        >$400-$700 AUD</span
+                        >$440-$770 AUD (including GST)</span
                       >
                     </div>
                     <div class="flex justify-between items-start">
@@ -123,7 +123,7 @@ import Image from '../components/Image.astro';
                         <span class="font-semibold block">Add-on: 360° spins or stop-motion</span>
                       </div>
                       <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                        >$100-$200 AUD</span
+                        >$110-$220 AUD (including GST)</span
                       >
                     </div>
                   </div>
@@ -164,11 +164,11 @@ import Image from '../components/Image.astro';
                 <div class="bg-gray-50 rounded-lg p-4 space-y-3">
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Per Image</span>
-                    <span class="text-xl font-bold text-gray-800">$10-$30 AUD</span>
+                    <span class="text-xl font-bold text-gray-800">$11-$33 AUD (including GST)</span>
                   </div>
                   <div class="flex justify-between items-center">
                     <span class="font-semibold">Bulk (20+ images)</span>
-                    <span class="text-xl font-bold text-gray-800">$8-$20 AUD per image</span>
+                    <span class="text-xl font-bold text-gray-800">$8.80-$22 AUD per image (including GST)</span>
                   </div>
                 </div>
               </div>
@@ -210,7 +210,7 @@ import Image from '../components/Image.astro';
                       <span class="text-sm text-gray-600">15-60 seconds</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$300-$800 AUD</span
+                      >$330-$880 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -219,7 +219,7 @@ import Image from '../components/Image.astro';
                       <span class="text-sm text-gray-600">1-2 minutes</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$1,000-$2,500 AUD</span
+                      >$1,100-$2,750 AUD (including GST)</span
                     >
                   </div>
                   <div class="flex justify-between items-start">
@@ -228,7 +228,7 @@ import Image from '../components/Image.astro';
                       <span class="text-sm text-gray-600">2-5 minutes</span>
                     </div>
                     <span class="text-xl font-bold text-gray-800 whitespace-nowrap ml-4"
-                      >$1,500-$3,500 AUD</span
+                      >$1,650-$3,850 AUD (including GST)</span
                     >
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Added 10% GST to all service prices across the website
- Included "(including GST)" label next to every price for transparency
- Updated 6 service pages with GST-inclusive pricing

## Changes Made
- ✅ `audio-services.astro` - Updated podcast editing, voiceover, mixing, and audio production prices
- ✅ `branding-identity.astro` - Updated logo design, brand identity, and business card prices
- ✅ `print-marketing-design.astro` - Updated brochure, flyer, and print design prices
- ✅ `services.astro` - Updated starting prices on main services overview page
- ✅ `social-media-design.astro` - Updated social media graphics and content package prices
- ✅ `visual-content-creation.astro` - Updated photography, video production, and editing prices

## Validation
- All price calculations verified to ensure exact 10% increase
- Linting and type checking passed successfully
- No errors or warnings in the build process

## Test Plan
- [ ] Verify all prices display correctly on each service page
- [ ] Confirm "(including GST)" text appears next to all prices
- [ ] Check that the website builds and deploys without errors
- [ ] Review pricing consistency across all pages