### PR TITLE
Fix yellow text readability and enable sticky CI comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -96,8 +96,8 @@ jobs:
             
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          # Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
+          use_sticky_comment: true
           
           # Optional: Customize review based on file types
           # direct_prompt: |

--- a/src/pages/services.astro
+++ b/src/pages/services.astro
@@ -46,7 +46,7 @@ import Image from '../components/Image.astro';
               Complete brand identity packages including logos, business cards, letterheads, and
               brand guidelines.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $200 AUD</p>
+            <p class="text-gray-800 font-bold">Starting from $200 AUD</p>
           </div>
         </Link>
 
@@ -71,7 +71,7 @@ import Image from '../components/Image.astro';
               Professional brochures, flyers, posters, and marketing materials that capture
               attention.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $150 AUD</p>
+            <p class="text-gray-800 font-bold">Starting from $150 AUD</p>
           </div>
         </Link>
 
@@ -95,7 +95,7 @@ import Image from '../components/Image.astro';
             <p class="text-gray-600 mb-4">
               Eye-catching social media graphics and content packages for all platforms.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $50 AUD</p>
+            <p class="text-gray-800 font-bold">Starting from $50 AUD</p>
           </div>
         </Link>
 
@@ -119,7 +119,7 @@ import Image from '../components/Image.astro';
             <p class="text-gray-600 mb-4">
               Photography, photo editing, video production, and visual storytelling.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $100 AUD</p>
+            <p class="text-gray-800 font-bold">Starting from $100 AUD</p>
           </div>
         </Link>
 
@@ -143,7 +143,7 @@ import Image from '../components/Image.astro';
             <p class="text-gray-600 mb-4">
               Podcast editing, music production, voiceovers, and audio branding.
             </p>
-            <p class="text-watt-yellow font-semibold">Starting from $100 AUD</p>
+            <p class="text-gray-800 font-bold">Starting from $100 AUD</p>
           </div>
         </Link>
 
@@ -171,7 +171,7 @@ import Image from '../components/Image.astro';
             Have a unique project in mind? Let's discuss your specific needs and create a custom
             solution.
           </p>
-          <Link href="/contact" class="text-watt-yellow font-semibold hover:underline">
+          <Link href="/contact" class="text-gray-800 font-bold hover:text-watt-yellow hover:underline transition-colors">
             Get in Touch →
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- Fixed readability issues with yellow text on white backgrounds
- Enabled sticky comments in Claude code review workflow

## Problem
The yellow price text (#ffee00) on the services page was difficult to read against white backgrounds, impacting user experience and accessibility.

## Solution
- Changed price text from `text-watt-yellow` to `text-gray-800` for better contrast
- Updated "Get in Touch" link to use gray text with yellow hover effect
- Maintained brand consistency by keeping yellow for interactive hover states

## Changes Made

### Services Page (`src/pages/services.astro`)
- ✅ Changed all "Starting from $XXX AUD" text from yellow to dark gray
- ✅ Updated "Get in Touch" link to gray with yellow hover effect
- ✅ Improved overall readability while maintaining brand aesthetics

### CI/CD Workflow (`claude-code-review.yml`)
- ✅ Enabled `use_sticky_comment: true` for better PR review management
- ✅ Claude will now reuse the same comment thread on subsequent PR updates

## Visual Impact
- **Before**: Bright yellow text (#ffee00) on white background - poor contrast
- **After**: Dark gray text (#1f2937) on white background - excellent contrast
- Yellow color preserved for hover states to maintain brand identity

## Test Plan
- [ ] Verify all price text is clearly readable on the services page
- [ ] Confirm hover effects still show yellow color
- [ ] Check that the page maintains visual consistency
- [ ] Verify CI/CD workflow runs with sticky comments enabled